### PR TITLE
Update marker popup design and maps default state

### DIFF
--- a/components/Map/index.jsx
+++ b/components/Map/index.jsx
@@ -4,8 +4,7 @@ import Marker from '~/components/Marker';
 const tiles = [
   {
     name: 'Light',
-    url: 'https://tiles.stadiamaps.com/tiles/alidade_smooth/{z}/{x}/{y}{r}.png',
-    checked: true
+    url: 'https://tiles.stadiamaps.com/tiles/alidade_smooth/{z}/{x}/{y}{r}.png'
   },
   {
     name: 'Dark',
@@ -13,7 +12,8 @@ const tiles = [
   },
   {
     name: 'Earth',
-    url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
+    url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+    checked: true
   }
 ];
 

--- a/components/Map/index.jsx
+++ b/components/Map/index.jsx
@@ -3,17 +3,17 @@ import Marker from '~/components/Marker';
 
 const tiles = [
   {
-    name: 'Earth',
-    url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-    checked: true
-  },
-  {
     name: 'Light',
-    url: 'https://tiles.stadiamaps.com/tiles/alidade_smooth/{z}/{x}/{y}{r}.png'
+    url: 'https://tiles.stadiamaps.com/tiles/alidade_smooth/{z}/{x}/{y}{r}.png',
+    checked: true
   },
   {
     name: 'Dark',
     url: 'https://tiles.stadiamaps.com/tiles/alidade_smooth_dark/{z}/{x}/{y}{r}.png'
+  },
+  {
+    name: 'Earth',
+    url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
   }
 ];
 
@@ -29,8 +29,8 @@ const Tile = ({ url, name, checked }) => (
 export default function Map({ pins }) {
   return (
     <MapContainer
-      center={[40, 0]}
-      zoom={5}
+      center={[41.56157392223945, -8.397397824887639]}
+      zoom={3.4}
       scrollWheelZoom={true}
       style={{ height: '100vh' }}
     >

--- a/components/Marker/index.jsx
+++ b/components/Marker/index.jsx
@@ -65,8 +65,10 @@ const Marker = ({ type, coordinates, city, country, author, photo, date }) => {
       <Popup>
         <div>
           <div className={styles.text}>
-            <h1>{country}</h1>
-            <h2>{city}</h2>
+            <h1>
+              {city},<br />
+              {country}
+            </h1>
             {date && (
               <i>
                 {getFullDateString(date)} ({getRelativeTimeString(date)})
@@ -80,6 +82,7 @@ const Marker = ({ type, coordinates, city, country, author, photo, date }) => {
             src={photo}
             layout="fill"
             objectFit="cover"
+            style={{ borderRadius: '10px', overflow: 'hidden' }}
           />
         </div>
       </Popup>

--- a/components/Marker/style.module.css
+++ b/components/Marker/style.module.css
@@ -3,6 +3,6 @@
   z-index: 50;
   color: white;
   bottom: 20px;
-  text-shadow: 0px 0px 5px black;
+  text-shadow: 0px 0px 5px rgba(0, 0, 0, 0.6);
   font-weight: 500;
 }


### PR DESCRIPTION
- Tweaked the look of the marker popup, making the image corners round and
updating the look of the city and country text;

- Changed the maps default state to be centered on the CeSIUM headquarters,
with the zoom more widely adjusted and with the light theme active.

![image](https://user-images.githubusercontent.com/80540164/180843166-d0a440a9-be27-4134-a097-fad4c4e630a0.png)
