### PR TITLE
Fix Ljubljana city name 🔧

### DIFF
--- a/data/places.json
+++ b/data/places.json
@@ -219,7 +219,7 @@
   {
     "author": ["Filipe Felício", "Matilde Bravo", "José Nuno Macedo"],
     "type": "picture",
-    "city": "Luibliana",
+    "city": "Ljubljana",
     "country": "Slovenia",
     "coordinates": [46.05218163654292, 14.511751028966621],
     "date": "2022-07-10",


### PR DESCRIPTION
Fixed a mistype of the city name in the Slovenia entry by Filipe Felício, Matilde Bravo and José Nuno Macedo.