### PR TITLE
Show key information when hovering a marker

### DIFF
--- a/components/Marker/index.tsx
+++ b/components/Marker/index.tsx
@@ -47,7 +47,11 @@ const Marker = ({
   const icon = getIcon(type);
 
   return (
-    <MarkerContainer icon={icon} position={coordinates}>
+    <MarkerContainer
+      icon={icon}
+      position={coordinates}
+      title={`${getNameString(author)} at ${city}`}
+    >
       <Popup>
         <div>
           <div className={styles.text}>


### PR DESCRIPTION
Defined the `title` property in `<MarkerContainer>` allowing to display a small description with the key information of a pin when hovering its respective marker.

![image](https://user-images.githubusercontent.com/80540164/181645897-f204a90b-85aa-42ce-aa58-c7646dd30c73.png)

