### PR TITLE
Fix bug caused by `.pop()` method 🔧

### DIFF
--- a/components/Marker/index.tsx
+++ b/components/Marker/index.tsx
@@ -45,12 +45,13 @@ const Marker = ({
   date
 }: Pin) => {
   const icon = getIcon(type);
+  const authors = getNameString(author);
 
   return (
     <MarkerContainer
       icon={icon}
       position={coordinates}
-      title={`${getNameString(author)} at ${city}`}
+      title={`${authors} at ${city}`}
     >
       <Popup>
         <div>
@@ -65,10 +66,10 @@ const Marker = ({
               </i>
             )}
             <br />
-            <span>{getNameString(author)}</span>
+            <span>{authors}</span>
           </div>
           <Image
-            alt={`${getNameString(author)} at ${city}`}
+            alt={`${authors} at ${city}`}
             src={photo}
             layout="fill"
             objectFit="cover"


### PR DESCRIPTION
Fixed bug caused by the repeated used of `getNameString()` on entries with more than two authors, the `author` array would get subsequently popped, reducing the number of authors along the way.
Since the array is only used for this purpose, I fixed it by only using the function once and saving the result to a variable. Should I make sure the array isn't changed in `getNameString()` instead?
