### PR TITLE
Improve `Sort by` feature

### DIFF
--- a/components/Location/Location.tsx
+++ b/components/Location/Location.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import { getRelativeTimeString, getNameString } from '~/lib/utils';
+import { getRelativeTimeString, getNameString, distance } from '~/lib/utils';
 import styles from './style.module.css';
 import { useMemo } from 'react';
 
@@ -11,7 +11,8 @@ const Location = ({
   date,
   coordinates,
   map,
-  setOpen
+  setOpen,
+  sortKey
 }) => {
   const name = useMemo(() => getNameString(author), [author]);
 
@@ -20,6 +21,25 @@ const Location = ({
       setOpen(false);
     }
     map.flyTo(coordinates, 10);
+  };
+
+  const getItalic = () => {
+    if (sortKey === 'Date') {
+      return getRelativeTimeString(date);
+    }
+    const x0 = 41.56157392223945;
+    const y0 = -8.397397824887639;
+
+    return (
+      Math.round(distance(x0, coordinates[0], y0, coordinates[1])) + ' km away'
+    );
+  };
+
+  const getIcon = () => {
+    if (sortKey === 'Distance') {
+      return <i className="bi bi-signpost-fill"></i>;
+    }
+    return <i className="bi bi-hourglass-split"></i>;
   };
 
   return (
@@ -40,7 +60,9 @@ const Location = ({
           </b>
         </p>
         <p className={styles.paragraph}>
-          {date && <i>{getRelativeTimeString(date)}</i>}
+          <i>
+            {getIcon()} {getItalic()}
+          </i>
         </p>
         <p className={styles.paragraph}>
           <span className={styles.authors}>{name}</span>

--- a/components/Map/Map.tsx
+++ b/components/Map/Map.tsx
@@ -45,6 +45,7 @@ export default function Map({ pins, setMapRef }: Props) {
       scrollWheelZoom={true}
       style={{ height: '100vh' }}
       zoomControl={false}
+      attributionControl={true}
     >
       <Ref></Ref>
       <LayersControl position="topright">

--- a/components/Sidebar/Sidebar.tsx
+++ b/components/Sidebar/Sidebar.tsx
@@ -6,17 +6,20 @@ import Location from '~/components/Location';
 import styles from './style.module.css';
 import { CSSTransition } from 'react-transition-group';
 import Leaderboard from '~/components/Leaderboard';
-import { Props, ESortKeys } from './types';
+import { Props, ESortKeys, ESortDirection } from './types';
 import { sortingFunctions, changeVariables } from './utils';
 
 export default function Sidebar({ pins, isOpen, setOpen, mapRef }: Props) {
   const [locations, setLocations] = useState<boolean>(true);
   const [leaderboard, setLeaderboard] = useState<boolean>(false);
-  const [sortKey, setSortKey] = useState<ESortKeys>(ESortKeys.Latest);
+  const [sortKey, setSortKey] = useState<ESortKeys>(ESortKeys.Date);
+  const [sortDirection, setSortDirection] = useState<ESortDirection>(
+    ESortDirection.Ascending
+  );
 
   const sortedPins = useMemo(
-    () => pins.sort(sortingFunctions[sortKey]),
-    [pins, sortKey]
+    () => pins.sort(sortingFunctions(sortKey, sortDirection)),
+    [pins, sortKey, sortDirection]
   );
 
   const getButtonStyle = (button: string) => {
@@ -115,6 +118,15 @@ export default function Sidebar({ pins, isOpen, setOpen, mapRef }: Props) {
                       </option>
                     ))}
                   </select>
+                  <select
+                    onChange={(e) =>
+                      setSortDirection(e.target.value as ESortDirection)
+                    }
+                    className={styles.sort_button}
+                  >
+                    <option>↓</option>
+                    <option>↑</option>
+                  </select>
                 </div>
               </div>
               {sortedPins.map((pin: IPin) => (
@@ -128,6 +140,7 @@ export default function Sidebar({ pins, isOpen, setOpen, mapRef }: Props) {
                   coordinates={pin.coordinates}
                   map={mapRef}
                   setOpen={setOpen}
+                  sortKey={sortKey}
                 />
               ))}
             </div>

--- a/components/Sidebar/types.ts
+++ b/components/Sidebar/types.ts
@@ -8,7 +8,11 @@ export interface Props {
 }
 
 export enum ESortKeys {
-  Latest = 'Latest',
-  Oldest = 'Oldest',
+  Date = 'Date',
   Distance = 'Distance'
+}
+
+export enum ESortDirection {
+  Ascending = '↓',
+  Descending = '↑'
 }

--- a/components/Sidebar/utils.ts
+++ b/components/Sidebar/utils.ts
@@ -1,27 +1,8 @@
-import { ESortKeys } from './types';
+import { ESortDirection, ESortKeys } from './types';
 import { DateTime } from 'luxon';
-import { sortByOldest } from '~/lib/utils';
+import { sortByOldest, distance } from '~/lib/utils';
 
-function distance(lat1, lat2, lon1, lon2) {
-  lon1 = (lon1 * Math.PI) / 180;
-  lon2 = (lon2 * Math.PI) / 180;
-  lat1 = (lat1 * Math.PI) / 180;
-  lat2 = (lat2 * Math.PI) / 180;
-
-  let dlon = lon2 - lon1;
-  let dlat = lat2 - lat1;
-  let a =
-    Math.pow(Math.sin(dlat / 2), 2) +
-    Math.cos(lat1) * Math.cos(lat2) * Math.pow(Math.sin(dlon / 2), 2);
-
-  let c = 2 * Math.asin(Math.sqrt(a));
-
-  let r = 6371;
-
-  return c * r;
-}
-
-export const sortByDistance = (a, b) => {
+export const sortByDistanceAscending = (a, b) => {
   const x0 = 41.56157392223945;
   const y0 = -8.397397824887639;
 
@@ -36,16 +17,46 @@ export const sortByDistance = (a, b) => {
   return d1 - d2;
 };
 
+export const sortByDistanceDescending = (a, b) => {
+  const x0 = 41.56157392223945;
+  const y0 = -8.397397824887639;
+
+  const x1 = a.coordinates[0];
+  const y1 = a.coordinates[1];
+  const x2 = b.coordinates[0];
+  const y2 = b.coordinates[1];
+
+  const d1 = distance(x0, x1, y0, y1);
+  const d2 = distance(x0, x2, y0, y2);
+
+  return d2 - d1;
+};
+
 export const sortByLatest = (a, b) => {
   return (
     DateTime.fromISO(b.date).toMillis() - DateTime.fromISO(a.date).toMillis()
   );
 };
 
-export const sortingFunctions = {
-  [ESortKeys.Latest]: sortByLatest,
-  [ESortKeys.Oldest]: sortByOldest,
-  [ESortKeys.Distance]: sortByDistance
+export const sortingFunctions = (sortKey, sortDirection) => {
+  switch (sortKey) {
+    case ESortKeys.Date: {
+      switch (sortDirection) {
+        case ESortDirection.Ascending:
+          return sortByLatest;
+        case ESortDirection.Descending:
+          return sortByOldest;
+      }
+    }
+    case ESortKeys.Distance: {
+      switch (sortDirection) {
+        case ESortDirection.Ascending:
+          return sortByDistanceAscending;
+        case ESortDirection.Descending:
+          return sortByDistanceDescending;
+      }
+    }
+  }
 };
 
 export function changeVariables(

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,5 +1,24 @@
 import { DateTime } from 'luxon';
 
+export function distance(lat1, lat2, lon1, lon2) {
+  lon1 = (lon1 * Math.PI) / 180;
+  lon2 = (lon2 * Math.PI) / 180;
+  lat1 = (lat1 * Math.PI) / 180;
+  lat2 = (lat2 * Math.PI) / 180;
+
+  let dlon = lon2 - lon1;
+  let dlat = lat2 - lat1;
+  let a =
+    Math.pow(Math.sin(dlat / 2), 2) +
+    Math.cos(lat1) * Math.cos(lat2) * Math.pow(Math.sin(dlon / 2), 2);
+
+  let c = 2 * Math.asin(Math.sqrt(a));
+
+  let r = 6371;
+
+  return c * r;
+}
+
 export const getRelativeTimeString = (date: string) => {
   return DateTime.fromISO(date)
     .toRelative(Date.now())


### PR DESCRIPTION
Improved the `Sort by` feature by adding a control for the sort direction, enabling the user to sort the pins by Ascending or Descending order for each sort variable. So now, instead of sorting by `Latest` or `Oldest`, we sort by Ascending Date (↓) or Descending Date (↑), same for Distance.

Also, now we can see how far away a pin is from the CeSIUM headquarters when we sort the pins by Distance. As you can see I added some icons to better distinguish between time view and distance view.

**Date:**

![image](https://user-images.githubusercontent.com/80540164/192146241-f6cd2ca4-5b66-4cf3-8502-2ac7684fb95f.png)

**Distance:**

![image](https://user-images.githubusercontent.com/80540164/192146254-2bacbcf0-74d3-4ba0-a7d8-382ea7536ddc.png)


