### PR TITLE
fix: marker layout incompatibility

### DIFF
--- a/components/Marker/Marker.tsx
+++ b/components/Marker/Marker.tsx
@@ -64,7 +64,6 @@ const Marker = ({
             src={photo}
             width={width}
             height={height}
-            layout="fill"
             className={localStyles.roundedImage}
           />
           <div className={localStyles.textOverlay}>

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.


### PR DESCRIPTION
The `layout` attribute cannot be used together with `width`. This was causing errors on the development environment.